### PR TITLE
Streaming url generator

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
@@ -78,7 +78,7 @@ module Hyrax
           # @see https://github.com/samvera-labs/iiif_manifest
           if solr_document['derivatives_metadata_ssi'].present?
             files_metadata = JSON.parse(solr_document['derivatives_metadata_ssi'])
-            external_files = files_metadata.select { |f| f['external_file_uri'].present? }
+            external_files = files_metadata.select { |f| f['file_location_uri'].present? }
             unless external_files.empty?
               return external_files.map do |f|
                 url = Hyrax.config.iiif_av_url_builder.call(
@@ -104,7 +104,7 @@ module Hyrax
         def audio_content
           if solr_document['derivatives_metadata_ssi'].present?
             files_metadata = JSON.parse(solr_document['derivatives_metadata_ssi'])
-            external_files = files_metadata.select { |f| f['external_file_uri'].present? }
+            external_files = files_metadata.select { |f| f['file_location_uri'].present? }
             unless external_files.empty?
               return external_files.map do |f|
                 url = Hyrax::IiifAv.config.iiif_av_url_builder.call(

--- a/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
@@ -78,7 +78,7 @@ module Hyrax
           # @see https://github.com/samvera-labs/iiif_manifest
           streams = stream_urls
           if streams.present?
-            streams.collect { |label, url| audio_display_content(url, label) }
+            streams.collect { |label, url| video_display_content(url, label) }
           else
             [video_display_content(download_path('mp4'), 'mp4'), video_display_content(download_path('webm'), 'webm')]
           end

--- a/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
@@ -81,9 +81,11 @@ module Hyrax
             external_files = files_metadata.select { |f| f['external_file_uri'].present? }
             unless external_files.empty?
               return external_files.map do |f|
-                uri = URI(f['external_file_uri'])
-                uri = URI.join(request.base_url, uri) if uri.relative?
-                video_display_content(uri, f['label'])
+                url = Hyrax.config.iiif_av_url_builder.call(
+                  f['file_location_uri'],
+                  request.base_url
+                )
+                video_display_content(url, f['label'])
               end
             end
           end
@@ -103,7 +105,15 @@ module Hyrax
           if solr_document['derivatives_metadata_ssi'].present?
             files_metadata = JSON.parse(solr_document['derivatives_metadata_ssi'])
             external_files = files_metadata.select { |f| f['external_file_uri'].present? }
-            return external_files.map { |f| audio_display_content(f['external_file_uri'], f['label']) } unless external_files.empty?
+            unless external_files.empty?
+              return external_files.map do |f|
+                url = Hyrax::IiifAv.config.iiif_av_url_builder.call(
+                  f['file_location_uri'],
+                  request.base_url
+                )
+                audio_display_content(url, f['label'])
+              end
+            end
           end
           [audio_display_content(download_path('ogg'), 'ogg'), audio_display_content(download_path('mp3'), 'mp3')]
         end

--- a/hyrax-iiif_av.gemspec
+++ b/hyrax-iiif_av.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |s|
 
   # Pin sass to avoid bug
   s.add_development_dependency 'sass', '=3.6.0'
+  # Pin hiredis
+  s.add_development_dependency 'hiredis', '=0.6.1'
 end

--- a/hyrax-iiif_av.gemspec
+++ b/hyrax-iiif_av.gemspec
@@ -30,9 +30,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'rails-controller-testing'
   s.add_development_dependency 'rspec-rails', '~> 3.8'
-
-  # Pin sass to avoid bug
-  s.add_development_dependency 'sass', '=3.6.0'
-  # Pin hiredis
-  s.add_development_dependency 'hiredis', '=0.6.1'
 end

--- a/lib/hyrax/iiif_av.rb
+++ b/lib/hyrax/iiif_av.rb
@@ -3,6 +3,25 @@ require "hyrax/iiif_av/engine"
 
 module Hyrax
   module IiifAv
-    # Your code goes here...
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :Configuration
+    end
+
+    # @api public
+    #
+    # Exposes the Hyrax configuration
+    #
+    # @yield [Hyrax::IiifAv::Configuration] if a block is passed
+    # @return [Hyrax::IiifAv::Configuration]
+    # @see Hyrax::IiifAv::Configuration for configuration options
+    def self.config(&block)
+      @config ||= Hyrax::IiifAv::Configuration.new
+
+      yield @config if block
+
+      @config
+    end
   end
 end

--- a/lib/hyrax/iiif_av/configuration.rb
+++ b/lib/hyrax/iiif_av/configuration.rb
@@ -8,9 +8,9 @@ module Hyrax
       def iiif_av_url_builder
         @iiif_av_url_builder ||= lambda do |file_location_uri, _base_url|
           # Reverse engineering Hyrax::DerivativePath
-          path = file_location_uri - Hyrax.config.derivatives_path
+          path = file_location_uri.sub(/^#{Hyrax.config.derivatives_path}/, '')
           id_path, file_path = path.split('-', 2)
-          file_set_id = id_path.gsum('/', '')
+          file_set_id = id_path.delete('/')
           filename = file_path[0, file_path.size / 2]
           Hyrax::Engine.routes.url_helpers.download_path(file_set_id, file: filename)
         end

--- a/lib/hyrax/iiif_av/configuration.rb
+++ b/lib/hyrax/iiif_av/configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Hyrax
+  module IiifAv
+    class Configuration
+      # URL that resolves to an AV stream provided to a IIIF presentation manifest
+      #
+      # @return [#call] lambda/proc that generates a URL to an AV stream
+      def iiif_av_url_builder
+        @iiif_av_url_builder ||= lambda do |file_location_uri, _base_url|
+          # Reverse engineering Hyrax::DerivativePath
+          path = file_location_uri - Hyrax.config.derivatives_path
+          id_path, file_path = path.split('-', 2)
+          file_set_id = id_path.gsum('/', '')
+          filename = file_path[0, file_path.size / 2]
+          Hyrax::Engine.routes.url_helpers.download_path(file_set_id, file: filename)
+        end
+      end
+      attr_writer :iiif_av_url_builder
+    end
+  end
+end

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -117,8 +117,8 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
             expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
             expect(content.length).to eq 2
             expect(content.map(&:label)).to match_array(['high', 'medium'])
-            expect(content.map(&:url)).to match_array(['http://streaming.example.com/stream/high.mp3',
-                                                       'http://streaming.example.com/stream/medium.mp3'])
+            expect(content.map(&:url)).to match_array(['http://streaming.example.com/stream/g-high.mp3.high.mp3',
+                                                       'http://streaming.example.com/stream/g-medium.mp3.medium.mp3'])
           end
         end
       end

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -82,8 +82,8 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
       context 'when the file is an audio derivative with metadata' do
         let(:derivatives_metadata) do
           [
-            { id: '1', label: 'high', external_file_uri: 'http://test.com/high.mp3' },
-            { id: '2', label: 'medium', external_file_uri: 'http://test.com/medium.mp3' }
+            { id: '1', label: 'high', file_location_uri: Hyrax::DerivativePath.derivative_path_for_reference(file_set_id, 'medium.mp3') },
+            { id: '2', label: 'medium', file_location_uri: Hyrax::DerivativePath.derivative_path_for_reference(file_set_id, 'high.mp3') }
           ]
         end
         let(:solr_document) { SolrDocument.new(id: '12345', duration_tesim: 1000, derivatives_metadata_ssi: derivatives_metadata.to_json) }
@@ -96,7 +96,29 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
           expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(content.length).to eq 2
           expect(content.map(&:label)).to match_array(['high', 'medium'])
-          expect(content.map(&:url)).to match_array(['http://test.com/high.mp3', 'http://test.com/medium.mp3'])
+          expect(content.map(&:url)).to match_array([Hyrax::Engine.routes.url_helpers.download_path(file_set, file: 'high.mp3'),
+                                                     Hyrax::Engine.routes.url_helpers.download_path(file_set, file: 'medium.mp3')])
+        end
+
+        context 'with custom av url builder' do
+          let(:custom_builder) do
+            ->(file_location_uri, _base_url) { "http://streaming.example.com/stream/#{File.basename(file_location_uri)}" }
+          end
+
+          around do |example|
+            default_builder = Hyrax::IiifAv.config.iiif_av_url_builder
+            Hyrax::IiifAv.config.iiif_av_url_builder = custom_builder
+            example.run
+            Hyrax::IiifAv.config.iiif_av_url_builder = default_builder
+          end
+
+          it 'creates an array of content objects with metadata' do
+            expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
+            expect(content.length).to eq 2
+            expect(content.map(&:label)).to match_array(['high', 'medium'])
+            expect(content.map(&:url)).to match_array(['http://streaming.example.com/stream/high.mp3',
+                                                       'http://streaming.example.com/stream/medium.mp3'])
+          end
         end
       end
 

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -80,6 +80,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
       end
 
       context 'when the file is an audio derivative with metadata' do
+        let(:file_set_id) { 'abcdefg' }
         let(:derivatives_metadata) do
           [
             { id: '1', label: 'high', file_location_uri: Hyrax::DerivativePath.derivative_path_for_reference(file_set_id, 'medium.mp3') },
@@ -96,8 +97,8 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
           expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(content.length).to eq 2
           expect(content.map(&:label)).to match_array(['high', 'medium'])
-          expect(content.map(&:url)).to match_array([Hyrax::Engine.routes.url_helpers.download_path(file_set, file: 'high.mp3'),
-                                                     Hyrax::Engine.routes.url_helpers.download_path(file_set, file: 'medium.mp3')])
+          expect(content.map(&:url)).to match_array([Hyrax::Engine.routes.url_helpers.download_path(file_set_id, file: 'high.mp3'),
+                                                     Hyrax::Engine.routes.url_helpers.download_path(file_set_id, file: 'medium.mp3')])
         end
 
         context 'with custom av url builder' do

--- a/spec/lib/hyrax/iiif_av/configuration_spec.rb
+++ b/spec/lib/hyrax/iiif_av/configuration_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyrax::IiifAv::Configuration do
+  subject { described_class.new }
+
+  it { is_expected.to respond_to(:iiif_av_url_builder) }
+  it { is_expected.to respond_to(:iiif_av_url_builder=) }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,8 +38,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-FactoryBot.definition_file_paths = [File.expand_path("spec/factories", Hyrax::Engine.root)]
-FactoryBot.find_definitions
+# FactoryBot.definition_file_paths = [File.expand_path("spec/factories", Hyrax::Engine.root)]
+# FactoryBot.find_definitions
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Part of samvera-labs/avalon-bundle#234.

Following the pattern of Hyrax, this commit adds a configuration with a
default streaming url generator that creates a Hyrax download url from a
derivative path, but allows replacing it with a custom generator.

Prior work done in https://github.com/samvera-labs/hyrax-active_encode/pull/12
Future work will be to write a custom streaming url generator in `avalon-bundle` to go with the default streaming setup.