### PR TITLE
IIIF Auth login autoclose and configure cors headers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   bixby: bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
 
 Naming/FileName:
@@ -22,6 +22,7 @@ Metrics/BlockLength:
     - 'spec/controllers/generic_works_controller_spec.rb'
     - 'spec/controllers/iiif_av_controller_spec.rb'
     - 'spec/helpers/iiif_av_helper_spec.rb'
+    - 'spec/requests/auth_controller_behavior_spec.rb'
 
 RSpec/VerifiedDoubles:
   Exclude:
@@ -40,3 +41,7 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   Exclude:
     - 'app/presenters/concerns/hyrax/iiif_av/displays_content.rb'
+
+Rails/OutputSafety:
+  Exclude:
+    - 'app/controllers/hyrax/iiif_av/iiif_av_controller.rb'

--- a/app/controllers/concerns/hyrax/iiif_av/auth_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/iiif_av/auth_controller_behavior.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright 2011-2018, The Trustees of Indiana University and Northwestern
+# University. Additional copyright may be held by others, as reflected in
+# the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module Hyrax
+  module IiifAv
+    module AuthControllerBehavior
+      extend ActiveSupport::Concern
+
+      def after_sign_in_path_for(resource_or_scope)
+        return Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_sign_in_path if referer_iiif_login? || request_iiif_login?
+        super
+      end
+
+      private
+
+        def referer_iiif_login?
+          # When going through the login form
+          referer_uri_string = request.env.fetch("HTTP_REFERER", nil)
+          return false unless referer_uri_string.present?
+          referer_uri = URI(referer_uri_string)
+          # Don't worry about referers that come from a different site (includings where the IIIF viewer is embedded)
+          return false if referer_uri.host.present? && referer_uri.host != request.host
+          query_params = Rack::Utils.parse_query(referer_uri.query)
+          query_params && ActiveModel::Type::Boolean.new.cast(query_params["iiif_auth_login"])
+        end
+
+        def request_iiif_login?
+          # When already logged in
+          request_uri_string = request.env.fetch("REQUEST_URI", nil)
+          return false unless request_uri_string.present?
+          request_uri = URI(request_uri_string)
+          query_params = Rack::Utils.parse_query(request_uri.query)
+          ActiveModel::Type::Boolean.new.cast(query_params["iiif_auth_login"])
+        end
+    end
+  end
+end

--- a/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
@@ -134,7 +134,7 @@ module Hyrax
         def auth_service
           {
             "context": "http://iiif.io/api/auth/1/context.json",
-            "@id": Rails.application.routes.url_helpers.new_user_session_url(host: request.base_url),
+            "@id": Rails.application.routes.url_helpers.new_user_session_url(host: request.base_url, iiif_auth_login: true),
             "@type": "AuthCookieService1",
             "confirmLabel": I18n.t('iiif_av.auth.confirmLabel'),
             "description": I18n.t('iiif_av.auth.description'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 Hyrax::IiifAv::Engine.routes.draw do
   get '/iiif_av/content/:id/:label', to: 'iiif_av#content', as: :iiif_av_content
   get '/iiif_av/auth_token/:id', to: 'iiif_av#auth_token', as: :iiif_av_auth_token
+  get '/iiif_av/sign_in', to: 'iiif_av#sign_in', as: :iiif_av_sign_in
 end

--- a/lib/generators/hyrax/iiif_av/install_generator.rb
+++ b/lib/generators/hyrax/iiif_av/install_generator.rb
@@ -6,8 +6,37 @@ module Hyrax
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
 
+      def install_rack_cors
+        gem 'rack-cors'
+        Bundler.with_clean_env do
+          run "bundle install"
+        end
+      end
+
+      def enable_cors
+        insert_into_file 'config/application.rb', after: 'class Application < Rails::Application' do
+          "\n" \
+          "    require 'rack/cors'\n" \
+          "    config.middleware.insert_before 0, Rack::Cors do\n" \
+          "      allow do\n" \
+          "        origins '*'\n" \
+          "        resource '/concern/*/*/manifest*', headers: :any, methods: [:head, :get]\n" \
+          "        resource '/iiif_av/*', headers: :any, methods: [:head, :get], expose: ['Content-Security-Policy']\n" \
+          "        resource '/downloads/*', headers: :any, methods: [:head, :get]\n" \
+          "      end\n" \
+          "    end\n" \
+        end
+      end
+
       def mount_routes
-        route "mount Hyrax::IiifAv::Engine => '/'"
+        route "mount Hyrax::IiifAv::Engine, at: '/'"
+      end
+
+      def override_devise_redirect_path
+        insert_into_file 'app/controllers/application_controller.rb', after: 'include Hyrax::Controller' do
+          "\n" \
+          "  include Hyrax::IiifAv::AuthControllerBehavior"
+        end
       end
     end
   end

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -173,7 +173,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
         end
 
         it 'provides a cookie auth service' do
-          expect(auth_service[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(host: request.base_url)
+          expect(auth_service[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(host: request.base_url, iiif_auth_login: true)
         end
 
         it 'provides a token service' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,5 +73,6 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/auth_controller_behavior_spec.rb
+++ b/spec/requests/auth_controller_behavior_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyrax::IiifAv::AuthControllerBehavior, type: :request do
+  describe 'after_sign_in_path_for' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:login_params) { { user: { email: user.user_key, password: user.password, remember_me: 0 }, commit: "Log in" } }
+
+    it 'redirects to self closing page when iiif_auth_login parameter present' do
+      headers = { "HTTP_REFERER" => Rails.application.routes.url_helpers.new_user_session_path(iiif_auth_login: true) }
+      post(Rails.application.routes.url_helpers.new_user_session_path, params: login_params, headers: headers)
+      expect(response).to redirect_to Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_sign_in_path
+    end
+
+    it 'redirects to the dashboard' do
+      headers = { "HTTP_REFERER" => Rails.application.routes.url_helpers.new_user_session_path }
+      post(Rails.application.routes.url_helpers.new_user_session_path, params: login_params, headers: headers)
+      expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path(locale: I18n.locale)
+    end
+
+    context 'when already logged in' do
+      before do
+        sign_in user
+      end
+
+      it 'redirects to self closing page when iiif_auth_login parameter present' do
+        get(Rails.application.routes.url_helpers.new_user_session_path(iiif_auth_login: true))
+        expect(response).to redirect_to Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_sign_in_path
+      end
+
+      it 'redirects to the dashboard' do
+        get(Rails.application.routes.url_helpers.new_user_session_path)
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path(locale: I18n.locale)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This has been installed in avalon-bundle and tested with the digirati auth testing page (https://digirati-co-uk.github.io/iiif-auth-client/?sources=https://mallorn.dlib.indiana.edu/iiif/index.json).  Note that a rails cache needs to be configured in order for auth tokens to work.

Related to https://github.com/samvera-labs/avalon-bundle/issues/274