### PR TITLE
UV support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 Gemfile.lock
 .internal_test_app
 .byebug_history
+vendor/bundle/**

--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ This will install `webpacker`, `react-rails`, and the avalon player (view partia
 4. Ingest audiovisual content and see a IIIF viewer render on the work show page.
 
 For a walkthrough of this in a demo application try running through this repository's README: https://github.com/avalonmediasystem/connect2018-workshop
+
+
+# Set up dev / test environment
+This project uses engine cart for testing and development purposes. To generate the .internal_test_app directory do the following
+
+```bash
+export ENGINE_CART_RAILS_OPTIONS="--skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-coffee --skip-puma --skip-test"
+bundle exec rake engine_cart:generate
+```
+
+Spec and rubocop can then be run using the `rake` command.

--- a/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content.rb
@@ -95,6 +95,7 @@ module Hyrax
                                                height: Array(solr_document.height).first.try(:to_i),
                                                duration: Array(solr_document.duration).first.try(:to_i) / 1000.0,
                                                type: 'Video',
+                                               format: solr_document.mime_type,
                                                auth_service: auth_service)
         end
 
@@ -112,6 +113,7 @@ module Hyrax
                                                label: label,
                                                duration: Array(solr_document.duration).first.try(:to_i) / 1000.0,
                                                type: 'Sound',
+                                               format: solr_document.mime_type,
                                                auth_service: auth_service)
         end
 

--- a/app/presenters/concerns/hyrax/iiif_av/displays_iiif_av.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_iiif_av.rb
@@ -38,7 +38,7 @@ module Hyrax
 
       def iiif_viewer
         if representative_presenter.video? || representative_presenter.audio?
-          Hyrax.config.iiif_av_viewer
+          Hyrax::IiifAv.config.iiif_av_viewer
         else
           super
         end

--- a/app/presenters/concerns/hyrax/iiif_av/displays_iiif_av.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_iiif_av.rb
@@ -38,7 +38,7 @@ module Hyrax
 
       def iiif_viewer
         if representative_presenter.video? || representative_presenter.audio?
-          :avalon
+          Hyrax.config.iiif_av_viewer
         else
           super
         end

--- a/lib/hyrax/iiif_av/configuration.rb
+++ b/lib/hyrax/iiif_av/configuration.rb
@@ -18,12 +18,13 @@ module Hyrax
       attr_writer :iiif_av_url_builder
 
       # A symbol that represents the viewer to render for AV items.
-      # Defaults to :avalon. Known to work with :universalviewer as well
+      # Defaults to :avalon. Known to work with :universal_viewer as well
 
       # @return [:symbol] viewer partial name
       def iiif_av_viewer
         @iiif_av_viewer ||= :avalon
       end
+      attr_writer :iiif_av_viewer
     end
   end
 end

--- a/lib/hyrax/iiif_av/configuration.rb
+++ b/lib/hyrax/iiif_av/configuration.rb
@@ -16,6 +16,14 @@ module Hyrax
         end
       end
       attr_writer :iiif_av_url_builder
+
+      # A symbol that represents the viewer to render for AV items.
+      # Defaults to :avalon. Known to work with :universalviewer as well
+
+      # @return [:symbol] viewer partial name
+      def iiif_av_viewer
+        @iiif_av_viewer ||= :avalon
+      end
     end
   end
 end

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -73,7 +73,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
           expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(content.length).to eq 2
           expect(content.map(&:type)).to all(eq 'Video')
-          expect(content.map(&:type)).to all(eq 'video/mp4')
+          expect(content.map(&:format)).to all(eq 'video/mp4')
           expect(content.map(&:width)).to all(eq 640)
           expect(content.map(&:height)).to all(eq 480)
           expect(content.map(&:duration)).to all(eq 1.000)

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
       end
 
       context "when the file is a sound recording" do
-        let(:solr_document) { SolrDocument.new(id: '12345', duration_tesim: 1000) }
+        let(:solr_document) { SolrDocument.new(id: '12345', duration_tesim: 1000, mime_type_ssi: 'audio/mp3') }
         let(:mp3_url) { "http://test.host/iiif_av/content/#{solr_document.id}/mp3" }
         let(:ogg_url) { "http://test.host/iiif_av/content/#{solr_document.id}/ogg" }
 
@@ -61,7 +61,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
       end
 
       context "when the file is a video" do
-        let(:solr_document) { SolrDocument.new(id: '12345', width_is: 640, height_is: 480, duration_tesim: 1000) }
+        let(:solr_document) { SolrDocument.new(id: '12345', width_is: 640, height_is: 480, duration_tesim: 1000, mime_type_ssi: 'video/mp4') }
         let(:mp4_url) { "http://test.host/iiif_av/content/#{id}/mp4" }
         let(:webm_url) { "http://test.host/iiif_av/content/#{id}/webm" }
 

--- a/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
+++ b/lib/hyrax/iiif_av/spec/shared_specs/displays_content.rb
@@ -53,6 +53,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
           expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(content.length).to eq 2
           expect(content.map(&:type)).to all(eq 'Sound')
+          expect(content.map(&:format)).to all(eq 'audio/mp3')
           expect(content.map(&:duration)).to all(eq 1.000)
           expect(content.map(&:label)).to match_array(['mp3', 'ogg'])
           expect(content.map(&:url)).to match_array([mp3_url, ogg_url])
@@ -72,6 +73,7 @@ RSpec.shared_examples "IiifAv::DisplaysContent" do
           expect(content).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(content.length).to eq 2
           expect(content.map(&:type)).to all(eq 'Video')
+          expect(content.map(&:type)).to all(eq 'video/mp4')
           expect(content.map(&:width)).to all(eq 640)
           expect(content.map(&:height)).to all(eq 480)
           expect(content.map(&:duration)).to all(eq 1.000)

--- a/spec/lib/hyrax/iiif_av/configuration_spec.rb
+++ b/spec/lib/hyrax/iiif_av/configuration_spec.rb
@@ -7,4 +7,6 @@ describe Hyrax::IiifAv::Configuration do
 
   it { is_expected.to respond_to(:iiif_av_url_builder) }
   it { is_expected.to respond_to(:iiif_av_url_builder=) }
+  it { is_expected.to respond_to(:iiif_av_viewer) }
+  it { is_expected.to respond_to(:iiif_av_viewer=) }
 end


### PR DESCRIPTION
UV needs format or it won't part the manifests. Also added a new config option to allow easy switching between the UV and Avalon view partials.  Marking this as draft since a) I'm not 100% through the implementation and b) I can not get the specs or rubicon to run locally yet so the tests are just my best guess at this point.